### PR TITLE
fix: incorrect uv mapping

### DIFF
--- a/Assets/Scripts/UVMap.cs
+++ b/Assets/Scripts/UVMap.cs
@@ -59,8 +59,8 @@ public class UVMap : MonoBehaviour
         blockUVs[14] = new Vector2(umin, vmax);
         blockUVs[15] = new Vector2(umax, vmin);
         blockUVs[16] = new Vector2(umin, vmin);
-        blockUVs[17] = new Vector2(umax, vmax);
-        blockUVs[18] = new Vector2(umin, vmax);
+        blockUVs[17] = new Vector2(umin, vmax);
+        blockUVs[18] = new Vector2(umax, vmax);
         blockUVs[19] = new Vector2(umax, vmin);
         blockUVs[20] = new Vector2(umin, vmin);
         blockUVs[21] = new Vector2(umax, vmax);


### PR DESCRIPTION
West side of block was incorrectly mapped.

Fixes from:

![image](https://user-images.githubusercontent.com/30170203/37297468-bdca2a30-2658-11e8-8744-8d01c7530231.png)

to:

![image](https://user-images.githubusercontent.com/30170203/37297492-cd8b8cde-2658-11e8-9e8c-4b7a1efab517.png)
