### PR TITLE
fix: player will not interact with nulls

### DIFF
--- a/Assets/Scripts/PlayerMouse.cs
+++ b/Assets/Scripts/PlayerMouse.cs
@@ -43,6 +43,7 @@ public class PlayerMouse : MonoBehaviour
         if (didRayCastHit)
         {
             BlockFaceBehaviour blockFace = hit.transform.gameObject.GetComponent<BlockFaceBehaviour>();
+            if (blockFace == null) return;
             BlockFace face = BlockFaceMethods.BlockFaceFromNormal(hit.normal);
             if (_faceMap.ContainsKey(blockFace) && _faceMap[blockFace].ClickableFace == face)
             {
@@ -59,6 +60,7 @@ public class PlayerMouse : MonoBehaviour
         if (didRayCastHit)
         {
             BlockFaceBehaviour blockFace = hit.transform.gameObject.GetComponent<BlockFaceBehaviour>();
+            if (blockFace == null) return;
             BlockFace face = BlockFaceMethods.BlockFaceFromNormal(hit.normal);
             if (_faceMap.ContainsKey(blockFace) && _faceMap[blockFace].ClickableFace == face)
             {


### PR DESCRIPTION
Previously if you were to walk to an edge of the block and press f, a null pointer exception will be thrown

To reproduce get to this position and press `f`
![image](https://user-images.githubusercontent.com/22221132/37950111-ed7d35a2-31c9-11e8-96bf-2ce2d6de703f.png)
