### PR TITLE
fix: particle effects removed on scene restart

### DIFF
--- a/Assets/ScriptableObjects/Plugin Scripts/FragilePlugin.cs
+++ b/Assets/ScriptableObjects/Plugin Scripts/FragilePlugin.cs
@@ -16,6 +16,7 @@ public class FragilePlugin : BlockPlugin
         if (!_isDestroyingItself && (_block.IsTranslating() || _block.IsPlayerStandingOn()))
         {
             _fragileEmitterInstantiated = Instantiate(FragileEmitter, _block.gameObject.transform.position, _block.gameObject.transform.rotation) as ParticleSystem;
+            UnityEngine.SceneManagement.SceneManager.MoveGameObjectToScene(_fragileEmitterInstantiated.gameObject, _block.gameObject.scene);
             _fragileEmitterInstantiated.GetComponent<ParticleSystemRenderer>().material = _block.gameObject.GetComponent<Renderer>().material;
             _fragileEmitterInstantiated.Play();
             Destroy(_fragileEmitterInstantiated.gameObject, BreakAfterTime + 1.5f);


### PR DESCRIPTION
Fixes issue where particles still stay in the scene when level reloads.