### PR TITLE
feat: add collectible score saving and display

### DIFF
--- a/Assets/Scenes/Stages/Main.unity
+++ b/Assets/Scenes/Stages/Main.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18725942, g: 0.92667246, b: 1.446396, a: 1}
+  m_IndirectSpecularColor: {r: 0.18749061, g: 0.9268341, b: 1.4464028, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -1378,7 +1378,7 @@ RectTransform:
   m_Children:
   - {fileID: 1629351631}
   m_Father: {fileID: 2002344983}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -2485,20 +2485,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8307ef3f34311e54b9f6034aa38567cb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _levelSelect: {fileID: 1210334151}
-  levelTextures:
+  LevelSelect: {fileID: 1210334151}
+  LevelName: {fileID: 1664137863}
+  PrimaryCollectibleNumber: {fileID: 561555405}
+  DefaultImageColor: {r: 0, g: 0, b: 0, a: 0}
+  CurrentlyChosenImageColor: {r: 0, g: 0, b: 0, a: 1}
+  LevelTextures:
   - {fileID: 21300000, guid: 17d8e36a01ed1504692458af9edab7f8, type: 3}
   - {fileID: 21300000, guid: 81090eb1aab79c741ba324bcdc8825bd, type: 3}
   - {fileID: 21300000, guid: a4b93386408784848a6a2cf3420d4e9a, type: 3}
   - {fileID: 21300000, guid: eb66741505abe9743aafbf0e755c967d, type: 3}
-  levelButtons:
+  CollectibleScores:
+  - {fileID: 11400000, guid: 6f51bf0ccd3199d488e24395e68e3b53, type: 2}
+  - {fileID: 11400000, guid: 98221086d8f9a9a4bbe26af90b00f185, type: 2}
+  - {fileID: 11400000, guid: f03eea87071a91c41aa5b1a15d6dec98, type: 2}
+  - {fileID: 11400000, guid: 64ae014df592d9649858e9617b8455b2, type: 2}
+  LevelButtons:
   - {fileID: 1963215278}
   - {fileID: 87510067}
   - {fileID: 672120738}
   - {fileID: 416709313}
-  defaultImageColor: {r: 0, g: 0, b: 0, a: 0}
-  currentlyChosenImageColor: {r: 0, g: 0, b: 0, a: 1}
-  _levelName: {fileID: 1664137863}
 --- !u!224 &1450650887
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2733,7 +2739,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1450650886}
-        m_MethodName: changeLevelSelected
+        m_MethodName: ChangeLevelSelected
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3127,7 +3133,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 2002344983}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0}
   m_AnchorMax: {x: 0.5, y: 0}
@@ -3285,7 +3291,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1450650886}
-        m_MethodName: changeLevelSelected
+        m_MethodName: ChangeLevelSelected
         m_Mode: 3
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -3361,8 +3367,8 @@ RectTransform:
   - {fileID: 1971789968}
   - {fileID: 1565722493}
   - {fileID: 1210334150}
-  - {fileID: 1963215276}
   - {fileID: 552351660}
+  - {fileID: 1963215276}
   - {fileID: 87510066}
   - {fileID: 672120737}
   - {fileID: 416709315}

--- a/Assets/Scenes/Stages/Stage 1/Stage_1.unity
+++ b/Assets/Scenes/Stages/Stage 1/Stage_1.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.1273174, g: 0.13414761, b: 0.12107885, a: 1}
+  m_IndirectSpecularColor: {r: 0.12731749, g: 0.13414757, b: 0.1210787, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
@@ -1210,6 +1210,59 @@ Transform:
   m_PrefabParentObject: {fileID: 4793059222212588, guid: 1c10f960ef25d9747959b1a640a32a4d,
     type: 2}
   m_PrefabInternal: {fileID: 37146502}
+--- !u!1001 &41867079
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1722492080}
+    m_Modifications:
+    - target: {fileID: 4098695893459986, guid: 621433f92b1188f4abef5b97f0607a60, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: -5.638103
+      objectReference: {fileID: 0}
+    - target: {fileID: 4098695893459986, guid: 621433f92b1188f4abef5b97f0607a60, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: -8.502152
+      objectReference: {fileID: 0}
+    - target: {fileID: 4098695893459986, guid: 621433f92b1188f4abef5b97f0607a60, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 4.089649
+      objectReference: {fileID: 0}
+    - target: {fileID: 4098695893459986, guid: 621433f92b1188f4abef5b97f0607a60, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4098695893459986, guid: 621433f92b1188f4abef5b97f0607a60, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4098695893459986, guid: 621433f92b1188f4abef5b97f0607a60, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4098695893459986, guid: 621433f92b1188f4abef5b97f0607a60, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4098695893459986, guid: 621433f92b1188f4abef5b97f0607a60, type: 2}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 621433f92b1188f4abef5b97f0607a60, type: 2}
+  m_IsPrefabParent: 0
+--- !u!114 &41867080 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 114930061533127284, guid: 621433f92b1188f4abef5b97f0607a60,
+    type: 2}
+  m_PrefabInternal: {fileID: 41867079}
+  m_Script: {fileID: 11500000, guid: a91a0f0bc9a64654baa8133d0bb6cd43, type: 3}
+--- !u!4 &41867081 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4098695893459986, guid: 621433f92b1188f4abef5b97f0607a60,
+    type: 2}
+  m_PrefabInternal: {fileID: 41867079}
 --- !u!1001 &44217011
 Prefab:
   m_ObjectHideFlags: 0
@@ -34642,6 +34695,59 @@ Transform:
   m_PrefabParentObject: {fileID: 4617227921920762, guid: a7d44ed2d77b7334f921650fa2a77e93,
     type: 2}
   m_PrefabInternal: {fileID: 1651553797}
+--- !u!1001 &1426853314
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1722492080}
+    m_Modifications:
+    - target: {fileID: 4733010725720110, guid: 948cd0013deb6854691fb42280948915, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: -7.802704
+      objectReference: {fileID: 0}
+    - target: {fileID: 4733010725720110, guid: 948cd0013deb6854691fb42280948915, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: -8.162153
+      objectReference: {fileID: 0}
+    - target: {fileID: 4733010725720110, guid: 948cd0013deb6854691fb42280948915, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 3.5150032
+      objectReference: {fileID: 0}
+    - target: {fileID: 4733010725720110, guid: 948cd0013deb6854691fb42280948915, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4733010725720110, guid: 948cd0013deb6854691fb42280948915, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4733010725720110, guid: 948cd0013deb6854691fb42280948915, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4733010725720110, guid: 948cd0013deb6854691fb42280948915, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4733010725720110, guid: 948cd0013deb6854691fb42280948915, type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 948cd0013deb6854691fb42280948915, type: 2}
+  m_IsPrefabParent: 0
+--- !u!114 &1426853315 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 114789318114038370, guid: 948cd0013deb6854691fb42280948915,
+    type: 2}
+  m_PrefabInternal: {fileID: 1426853314}
+  m_Script: {fileID: 11500000, guid: a91a0f0bc9a64654baa8133d0bb6cd43, type: 3}
+--- !u!4 &1426853316 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4733010725720110, guid: 948cd0013deb6854691fb42280948915,
+    type: 2}
+  m_PrefabInternal: {fileID: 1426853314}
 --- !u!1001 &1427321255
 Prefab:
   m_ObjectHideFlags: 0
@@ -43900,6 +44006,54 @@ Transform:
   m_PrefabParentObject: {fileID: 4908710523284210, guid: 8a342263ad1bea945ba2247f2b1fb639,
     type: 2}
   m_PrefabInternal: {fileID: 1721877092}
+--- !u!1 &1722492078
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1722492080}
+  - component: {fileID: 1722492079}
+  m_Layer: 0
+  m_Name: CollectiblesManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1722492079
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1722492078}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59c7fa5987719c745a8f9da514db48fc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CollectibleScoreObj: {fileID: 11400000, guid: 98221086d8f9a9a4bbe26af90b00f185,
+    type: 2}
+  PrimaryCollectibles:
+  - {fileID: 1426853315}
+  SecondaryCollectibles:
+  - {fileID: 41867080}
+--- !u!4 &1722492080
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1722492078}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 10.946849, y: 12.802153, z: 47.221107}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1426853316}
+  - {fileID: 41867081}
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1726855477
 Prefab:
   m_ObjectHideFlags: 0

--- a/Assets/ScriptableObjects/Collectibles.meta
+++ b/Assets/ScriptableObjects/Collectibles.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1b2508bc621a062449868a01a7c1c199
+folderAsset: yes
+timeCreated: 1523435132
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/CollectibleScore.cs
+++ b/Assets/ScriptableObjects/Collectibles/CollectibleScore.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using UnityEngine;
+
+[CreateAssetMenu]
+public class CollectibleScore : ScriptableObject
+{
+    [Header("Sub Scores (Based on Level)")]
+    public bool IsPuzzle;
+    public List<CollectibleScore> SubScores;
+
+    public List<bool> PrimaryCollectiblesCollected;
+    public List<bool> SecondaryCollectiblesCollected;
+
+    private List<bool> _primaryRecord;
+    private List<bool> _secondaryRecord;
+
+    public void SaveScore()
+    {
+        PrimaryCollectiblesCollected = _primaryRecord;
+        SecondaryCollectiblesCollected = _secondaryRecord;
+    }
+
+    public void StartRecordingScore()
+    {
+        _primaryRecord = new List<bool>(PrimaryCollectiblesCollected);
+        _secondaryRecord = new List<bool>(SecondaryCollectiblesCollected);
+    }
+
+    public void UpdateCollectedRecord(bool isPrimary, int index)
+    {
+        if (isPrimary)
+        {
+            _primaryRecord[index] = true;
+        }
+        else
+        {
+            _secondaryRecord[index] = true;
+        }
+    }
+
+    public List<bool> GetPrimaryCollectedInStage()
+    {
+        if (IsPuzzle)
+        {
+            return new List<bool>(PrimaryCollectiblesCollected);
+        }
+
+        List<bool> toReturn = new List<bool>();
+
+        foreach (CollectibleScore cs in SubScores)
+        {
+            toReturn.AddRange(cs.GetPrimaryCollectedInStage());
+        }
+
+        return toReturn;
+    }
+
+    public List<bool> GetSecondaryCollectedInStage()
+    {
+        if (IsPuzzle)
+        {
+            return new List<bool>(SecondaryCollectiblesCollected);
+        }
+
+        List<bool> toReturn = new List<bool>();
+
+        foreach (CollectibleScore cs in SubScores)
+        {
+            toReturn.AddRange(cs.GetSecondaryCollectedInStage());
+        }
+
+        return toReturn;
+    }
+}
+    

--- a/Assets/ScriptableObjects/Collectibles/CollectibleScore.cs.meta
+++ b/Assets/ScriptableObjects/Collectibles/CollectibleScore.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 7f7de22cf90dbe64380430db31146f6d
+timeCreated: 1523435164
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_1.asset
+++ b/Assets/ScriptableObjects/Collectibles/Stage_1.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7de22cf90dbe64380430db31146f6d, type: 3}
+  m_Name: Stage_1
+  m_EditorClassIdentifier: 
+  IsPuzzle: 1
+  SubScores: []
+  PrimaryCollectiblesCollected: 00
+  SecondaryCollectiblesCollected: 00

--- a/Assets/ScriptableObjects/Collectibles/Stage_1.asset.meta
+++ b/Assets/ScriptableObjects/Collectibles/Stage_1.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 98221086d8f9a9a4bbe26af90b00f185
+timeCreated: 1523435359
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_2.asset
+++ b/Assets/ScriptableObjects/Collectibles/Stage_2.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7de22cf90dbe64380430db31146f6d, type: 3}
+  m_Name: Stage_2
+  m_EditorClassIdentifier: 
+  IsPuzzle: 0
+  SubScores:
+  - {fileID: 11400000, guid: 043b9760fd95f8a44bf4afd1a0f5c005, type: 2}
+  - {fileID: 11400000, guid: 656b16c49f8fadc4799c060e3527fe9f, type: 2}
+  - {fileID: 11400000, guid: c02092a8fa078a14eabfb47f7b354f17, type: 2}
+  PrimaryCollectiblesCollected: 
+  SecondaryCollectiblesCollected: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_2.asset.meta
+++ b/Assets/ScriptableObjects/Collectibles/Stage_2.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: f03eea87071a91c41aa5b1a15d6dec98
+timeCreated: 1523440520
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_2_Part_1.asset
+++ b/Assets/ScriptableObjects/Collectibles/Stage_2_Part_1.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7de22cf90dbe64380430db31146f6d, type: 3}
+  m_Name: Stage_2_Part_1
+  m_EditorClassIdentifier: 
+  IsPuzzle: 1
+  SubScores: []
+  PrimaryCollectiblesCollected: 
+  SecondaryCollectiblesCollected: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_2_Part_1.asset.meta
+++ b/Assets/ScriptableObjects/Collectibles/Stage_2_Part_1.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 043b9760fd95f8a44bf4afd1a0f5c005
+timeCreated: 1523440540
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_2_Part_2.asset
+++ b/Assets/ScriptableObjects/Collectibles/Stage_2_Part_2.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7de22cf90dbe64380430db31146f6d, type: 3}
+  m_Name: Stage_2_Part_2
+  m_EditorClassIdentifier: 
+  IsPuzzle: 1
+  SubScores: []
+  PrimaryCollectiblesCollected: 
+  SecondaryCollectiblesCollected: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_2_Part_2.asset.meta
+++ b/Assets/ScriptableObjects/Collectibles/Stage_2_Part_2.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 656b16c49f8fadc4799c060e3527fe9f
+timeCreated: 1523440553
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_2_Part_3.asset
+++ b/Assets/ScriptableObjects/Collectibles/Stage_2_Part_3.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7de22cf90dbe64380430db31146f6d, type: 3}
+  m_Name: Stage_2_Part_3
+  m_EditorClassIdentifier: 
+  IsPuzzle: 1
+  SubScores: []
+  PrimaryCollectiblesCollected: 
+  SecondaryCollectiblesCollected: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_2_Part_3.asset.meta
+++ b/Assets/ScriptableObjects/Collectibles/Stage_2_Part_3.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: c02092a8fa078a14eabfb47f7b354f17
+timeCreated: 1523440569
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_3.asset
+++ b/Assets/ScriptableObjects/Collectibles/Stage_3.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7de22cf90dbe64380430db31146f6d, type: 3}
+  m_Name: Stage_3
+  m_EditorClassIdentifier: 
+  IsPuzzle: 0
+  SubScores:
+  - {fileID: 11400000, guid: 89762372c11c2cc4fbb6a15865438389, type: 2}
+  - {fileID: 11400000, guid: bb7e7b9277f7344478cb2265bb0631f3, type: 2}
+  - {fileID: 11400000, guid: 74818a22de26e8242bb031166477ff89, type: 2}
+  - {fileID: 11400000, guid: c0d8d51dbd4dd494d9306af083be5233, type: 2}
+  PrimaryCollectiblesCollected: 
+  SecondaryCollectiblesCollected: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_3.asset.meta
+++ b/Assets/ScriptableObjects/Collectibles/Stage_3.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 64ae014df592d9649858e9617b8455b2
+timeCreated: 1523440587
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_3_Part_1.asset
+++ b/Assets/ScriptableObjects/Collectibles/Stage_3_Part_1.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7de22cf90dbe64380430db31146f6d, type: 3}
+  m_Name: Stage_3_Part_1
+  m_EditorClassIdentifier: 
+  IsPuzzle: 1
+  SubScores: []
+  PrimaryCollectiblesCollected: 
+  SecondaryCollectiblesCollected: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_3_Part_1.asset.meta
+++ b/Assets/ScriptableObjects/Collectibles/Stage_3_Part_1.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 89762372c11c2cc4fbb6a15865438389
+timeCreated: 1523440592
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_3_Part_2.asset
+++ b/Assets/ScriptableObjects/Collectibles/Stage_3_Part_2.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7de22cf90dbe64380430db31146f6d, type: 3}
+  m_Name: Stage_3_Part_2
+  m_EditorClassIdentifier: 
+  IsPuzzle: 1
+  SubScores: []
+  PrimaryCollectiblesCollected: 
+  SecondaryCollectiblesCollected: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_3_Part_2.asset.meta
+++ b/Assets/ScriptableObjects/Collectibles/Stage_3_Part_2.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: bb7e7b9277f7344478cb2265bb0631f3
+timeCreated: 1523440600
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_3_Part_3.asset
+++ b/Assets/ScriptableObjects/Collectibles/Stage_3_Part_3.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7de22cf90dbe64380430db31146f6d, type: 3}
+  m_Name: Stage_3_Part_3
+  m_EditorClassIdentifier: 
+  IsPuzzle: 1
+  SubScores: []
+  PrimaryCollectiblesCollected: 
+  SecondaryCollectiblesCollected: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_3_Part_3.asset.meta
+++ b/Assets/ScriptableObjects/Collectibles/Stage_3_Part_3.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 74818a22de26e8242bb031166477ff89
+timeCreated: 1523440606
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_3_Part_4.asset
+++ b/Assets/ScriptableObjects/Collectibles/Stage_3_Part_4.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7de22cf90dbe64380430db31146f6d, type: 3}
+  m_Name: Stage_3_Part_4
+  m_EditorClassIdentifier: 
+  IsPuzzle: 1
+  SubScores: []
+  PrimaryCollectiblesCollected: 
+  SecondaryCollectiblesCollected: 

--- a/Assets/ScriptableObjects/Collectibles/Stage_3_Part_4.asset.meta
+++ b/Assets/ScriptableObjects/Collectibles/Stage_3_Part_4.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: c0d8d51dbd4dd494d9306af083be5233
+timeCreated: 1523440614
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/ScriptableObjects/Collectibles/Tutorial.asset
+++ b/Assets/ScriptableObjects/Collectibles/Tutorial.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7f7de22cf90dbe64380430db31146f6d, type: 3}
+  m_Name: Tutorial
+  m_EditorClassIdentifier: 
+  IsPuzzle: 1
+  SubScores: []
+  PrimaryCollectiblesCollected: 
+  SecondaryCollectiblesCollected: 

--- a/Assets/ScriptableObjects/Collectibles/Tutorial.asset.meta
+++ b/Assets/ScriptableObjects/Collectibles/Tutorial.asset.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 6f51bf0ccd3199d488e24395e68e3b53
+timeCreated: 1523440580
+licenseType: Free
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CollectiblesManager.cs
+++ b/Assets/Scripts/CollectiblesManager.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class CollectiblesManager : MonoBehaviour
+{
+
+    public CollectibleScore CollectibleScoreObj;
+    public List<CollectiblesScript> PrimaryCollectibles;
+    public List<CollectiblesScript> SecondaryCollectibles;
+
+    void Start()
+    {
+        CollectibleScoreObj.StartRecordingScore();
+        SceneController.Instance.RegisterCollectibleScore(CollectibleScoreObj);
+
+        //safeguard ourselves
+        if (PrimaryCollectibles.Count != CollectibleScoreObj.PrimaryCollectiblesCollected.Count)
+        {
+            Debug.Log("Make sure to update" + CollectibleScoreObj + " to reflect the correct number of Primary Collectibles");
+        }
+
+        if (SecondaryCollectibles.Count != CollectibleScoreObj.SecondaryCollectiblesCollected.Count)
+        {
+            Debug.Log("Make sure to update" + SecondaryCollectibles + " to reflect the correct number of Secondary Collectibles");
+        }
+
+        // update collected details
+        UpdateCollectedCollectibles(CollectibleScoreObj.PrimaryCollectiblesCollected, PrimaryCollectibles);
+        UpdateCollectedCollectibles(CollectibleScoreObj.SecondaryCollectiblesCollected, SecondaryCollectibles);
+    }
+
+    void UpdateCollectedCollectibles(List<bool> collectedMap, List<CollectiblesScript> collectibles)
+    {
+        for (int i = 0; i < collectedMap.Count; i++)
+        {
+            if (collectedMap[i])
+            {
+                collectibles[i].SetCollected();
+            }
+        }
+    }
+
+    void UpdateScore(CollectiblesScript collectiblesScript)
+    {
+        int index = PrimaryCollectibles.FindIndex(cs => cs == collectiblesScript);
+        bool isPrimary = index != -1;
+        if (!isPrimary)
+        {
+            index = SecondaryCollectibles.FindIndex(cs => cs == collectiblesScript);
+        }
+        CollectibleScoreObj.UpdateCollectedRecord(isPrimary, index);
+    }
+}

--- a/Assets/Scripts/CollectiblesManager.cs.meta
+++ b/Assets/Scripts/CollectiblesManager.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 59c7fa5987719c745a8f9da514db48fc
+timeCreated: 1523438352
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CollectiblesScript.cs
+++ b/Assets/Scripts/CollectiblesScript.cs
@@ -14,6 +14,12 @@ public class CollectiblesScript : MonoBehaviour
 
     private void OnTriggerEnter(Collider collision)
     {
+        SendMessageUpwards("UpdateScore", this);
         Destroy(this.gameObject);
+    }
+
+    public void SetCollected()
+    {
+        GetComponent<Renderer>().material.color = Color.grey;
     }
 }

--- a/Assets/Scripts/Menu.cs
+++ b/Assets/Scripts/Menu.cs
@@ -6,37 +6,41 @@ using UnityEngine.UI;
 
 public class Menu : MonoBehaviour
 {
+    [Header("Main Menu")]
+    public Button LevelSelect;
+    
+    [Header("Scene Menu UI")]
+    public Text LevelName;
+    public Text PrimaryCollectibleNumber;
+    public Color DefaultImageColor;
+    public Color CurrentlyChosenImageColor = Color.black;
+    public Sprite[] LevelTextures;
+    public CollectibleScore[] CollectibleScores;
+    public Image[] LevelButtons;
+
     private GameObject _player;
     private PlayerController _playerController;
 
-    private Canvas _canvas;
     private CameraController _camera;
     private bool _menuShowing = true;
     private GameObject _sceneMenu;
     private GameObject _mainMenu;
-    private GameObject _UI;
-    private GameObject _exitButtom;
-    public Button _levelSelect;
-
-    public Sprite[] levelTextures;
-    public Image[] levelButtons;
-    public Color defaultImageColor;
-    public Color currentlyChosenImageColor = Color.black;
-    private int currentLevelSelected = 0;
-    public Text _levelName;
-
+    private GameObject _ui;
+    private GameObject _exitButton;
+    
+    private int _currentLevelSelected = 0;
+    
     // Use this for initialization
     void Awake()
     {
-        _canvas = GetComponent<Canvas>();
-        defaultImageColor = levelButtons[0].color;
+        DefaultImageColor = LevelButtons[0].color;
         HideMenu(_sceneMenu = GameObject.Find("SceneMenu"));
         _mainMenu = GameObject.Find("MainMenu");
-        _exitButtom = GameObject.Find("ExitButton");
-        HideMenu(_UI = GameObject.Find("UI"));
-        levelButtons[currentLevelSelected].color = currentlyChosenImageColor;
-        _levelName.text = levelTextures[currentLevelSelected].name.Split('.')[0];
-        _levelSelect.image.sprite = levelTextures[currentLevelSelected];
+        _exitButton = GameObject.Find("ExitButton");
+        HideMenu(_ui = GameObject.Find("UI"));
+        LevelButtons[_currentLevelSelected].color = CurrentlyChosenImageColor;
+        LevelName.text = LevelTextures[_currentLevelSelected].name.Split('.')[0];
+        LevelSelect.image.sprite = LevelTextures[_currentLevelSelected];
     }
 
     // Update is called once per frame
@@ -73,9 +77,9 @@ public class Menu : MonoBehaviour
         _playerController.SetMobility(true);
         Cursor.lockState = CursorLockMode.Locked;
         Cursor.visible = false;
-        _exitButtom.SetActive(false);
+        _exitButton.SetActive(false);
         _menuShowing = false;
-        ShowMenu(_UI);
+        ShowMenu(_ui);
     }
 
     public void StopGame()
@@ -84,13 +88,17 @@ public class Menu : MonoBehaviour
         _playerController.SetMobility(false);
         Cursor.lockState = CursorLockMode.None;
         Cursor.visible = true;
-        _exitButtom.SetActive(true);
+        _exitButton.SetActive(true);
         _menuShowing = true;
-        HideMenu(_UI);
+        HideMenu(_ui);
     }
 
     public void ShowMenu(GameObject menu)
     {
+        if (menu == _sceneMenu)
+        {
+            ChangeLevelSelected(0);
+        }
         menu.SetActive(true);
     }
 
@@ -107,7 +115,7 @@ public class Menu : MonoBehaviour
 
     public void JumpToCurrentlySelectedLevel()
     {
-        JumpToLevel(levelTextures[currentLevelSelected].name.Split('.')[0]);
+        JumpToLevel(LevelTextures[_currentLevelSelected].name.Split('.')[0]);
     }
 
     public void JumpToLevel(string sceneName)
@@ -116,16 +124,17 @@ public class Menu : MonoBehaviour
         SceneController.Instance.LoadNewScene(sceneName);
     }
 
-    public void changeLevelSelected(int value)
+    public void ChangeLevelSelected(int value)
     {
-        levelButtons[currentLevelSelected].color = defaultImageColor;
-        currentLevelSelected += value;
-        if (currentLevelSelected < 0)
-            currentLevelSelected += levelTextures.Length;
-        if (currentLevelSelected >= levelTextures.Length)
-            currentLevelSelected -= levelTextures.Length;
-        levelButtons[currentLevelSelected].color = currentlyChosenImageColor;
-        _levelName.text = levelTextures[currentLevelSelected].name.Split('.')[0];
-        _levelSelect.image.sprite = levelTextures[currentLevelSelected];
+        LevelButtons[_currentLevelSelected].color = DefaultImageColor;
+        _currentLevelSelected += value;
+        if (_currentLevelSelected < 0)
+            _currentLevelSelected += LevelTextures.Length;
+        if (_currentLevelSelected >= LevelTextures.Length)
+            _currentLevelSelected -= LevelTextures.Length;
+        LevelButtons[_currentLevelSelected].color = CurrentlyChosenImageColor;
+        LevelName.text = LevelTextures[_currentLevelSelected].name.Split('.')[0];
+        LevelSelect.image.sprite = LevelTextures[_currentLevelSelected];
+        PrimaryCollectibleNumber.text = CollectibleScores[_currentLevelSelected].GetPrimaryCollectedInStage().Count.ToString();
     }
 }

--- a/Assets/Scripts/SceneController.cs
+++ b/Assets/Scripts/SceneController.cs
@@ -17,6 +17,7 @@ public class SceneController : MonoBehaviour
     private bool _isReloading = false;
     
     private int _sceneIndex = 0;
+    private CollectibleScore _collectibleScore;
 
     // we use Singleton Pattern
     public static SceneController Instance;
@@ -69,6 +70,11 @@ public class SceneController : MonoBehaviour
         }
     }
 
+    public void RegisterCollectibleScore(CollectibleScore cs)
+    {
+        _collectibleScore = cs;
+    }
+
     public void LoadNext()
     {
         Instance._loadNext();
@@ -76,7 +82,7 @@ public class SceneController : MonoBehaviour
 
     private void _loadNext()
     {
-
+        _collectibleScore.SaveScore();
         _sceneIndex++;
         if (_sceneIndex >= _toLoad.Count)
         {


### PR DESCRIPTION
To use:

**Only do this for puzzle levels**

1. Create a `GameObject` with `CollectiblesManager` script attached.
1. Add `PrimaryCollectible` and `SecondaryCollectible` prefabs as child of the `CollectiblesManager` gameobject in the hierachy.
1. Add `PrimaryCollectible` and `SecondaryCollectible` gameObjects in to `CollectiblesManager` list in the correct order
1. Add `CollectibleScore` Scriptable Object (found in project) to collectibles manager (this is based on the name)

**Note**: Ensure size length of `Primary Collectibles Collected` and `Secondary Collectibles Collected` is the same as per the puzzle. (Will not be automatically updated)