### PR TITLE
fix: fragile emitter no longer causes performance issues

### DIFF
--- a/Assets/Prefabs/Emitters/FragileEmitter.prefab
+++ b/Assets/Prefabs/Emitters/FragileEmitter.prefab
@@ -334,7 +334,7 @@ ParticleSystem:
     startSize:
       serializedVersion: 2
       minMaxState: 0
-      scalar: 0.1
+      scalar: 0.2
       minScalar: 1
       maxCurve:
         serializedVersion: 2
@@ -3519,7 +3519,7 @@ ParticleSystemRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_RenderMode: 4
+  m_RenderMode: 0
   m_SortMode: 0
   m_MinParticleSize: 0.0025
   m_MaxParticleSize: 0.0025

--- a/Assets/ScriptableObjects/Plugin Scripts/FragilePlugin.cs
+++ b/Assets/ScriptableObjects/Plugin Scripts/FragilePlugin.cs
@@ -15,7 +15,7 @@ public class FragilePlugin : BlockPlugin
     {
         if (!_isDestroyingItself && (_block.IsTranslating() || _block.IsPlayerStandingOn()))
         {
-            _fragileEmitterInstantiated = Instantiate(FragileEmitter, _block.gameObject.transform.position + Vector3.down, _block.gameObject.transform.rotation) as ParticleSystem;
+            _fragileEmitterInstantiated = Instantiate(FragileEmitter, _block.gameObject.transform.position, _block.gameObject.transform.rotation) as ParticleSystem;
             UnityEngine.SceneManagement.SceneManager.MoveGameObjectToScene(_fragileEmitterInstantiated.gameObject, _block.gameObject.scene);
             _fragileEmitterInstantiated.GetComponent<ParticleSystemRenderer>().material = _block.gameObject.GetComponent<Renderer>().material;
             _fragileEmitterInstantiated.Play();


### PR DESCRIPTION
Changed the emitter render mode from mesh to billboard to significantly improve performance.