### PR TITLE
fix: monster blocks are no longer super black upon displacement

### DIFF
--- a/Assets/Prefabs/MonsterBlock.prefab
+++ b/Assets/Prefabs/MonsterBlock.prefab
@@ -386,6 +386,9 @@ MonoBehaviour:
     type: 2}
   DestroyedSound: {fileID: 82828001692260854, guid: b47ef45978d91a5469544238047d57c4,
     type: 2}
+  SelfDestructEmitter: {fileID: 0}
+  GreyedOutColor: {r: 0.7137255, g: 0.7137255, b: 0.7137255, a: 0}
+  FadeInSpeed: 5
 --- !u!212 &212884392673552770
 SpriteRenderer:
   m_ObjectHideFlags: 1

--- a/Assets/Scenes/Stages/Stage 2/Stage_2_Part_1.unity
+++ b/Assets/Scenes/Stages/Stage 2/Stage_2_Part_1.unity
@@ -17686,7 +17686,7 @@ Prefab:
     - target: {fileID: 114715911418043306, guid: 55106369e1ec2f94591ed8cc6bbf077c,
         type: 2}
       propertyPath: Plugins.Array.size
-      value: 2
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4869944850807714, guid: 55106369e1ec2f94591ed8cc6bbf077c, type: 2}
       propertyPath: m_LocalPosition.x
@@ -17740,6 +17740,17 @@ Prefab:
       propertyPath: TransparentMaterial
       value: 
       objectReference: {fileID: 2100000, guid: 565fd81533bcc5242b3b82395a256e0e, type: 2}
+    - target: {fileID: 114715911418043306, guid: 55106369e1ec2f94591ed8cc6bbf077c,
+        type: 2}
+      propertyPath: Plugins.Array.data[1]
+      value: 
+      objectReference: {fileID: 11400000, guid: 759350186e48ca441b664570026cbf7b,
+        type: 2}
+    - target: {fileID: 23123771044120512, guid: 55106369e1ec2f94591ed8cc6bbf077c,
+        type: 2}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 5d36637cf511d1a4fa5175ea2867c23e, type: 2}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 55106369e1ec2f94591ed8cc6bbf077c, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/Scenes/Stages/Stage 2/Stage_2_Part_1.unity
+++ b/Assets/Scenes/Stages/Stage 2/Stage_2_Part_1.unity
@@ -17686,7 +17686,7 @@ Prefab:
     - target: {fileID: 114715911418043306, guid: 55106369e1ec2f94591ed8cc6bbf077c,
         type: 2}
       propertyPath: Plugins.Array.size
-      value: 0
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4869944850807714, guid: 55106369e1ec2f94591ed8cc6bbf077c, type: 2}
       propertyPath: m_LocalPosition.x


### PR DESCRIPTION
Thanks @reginleiff for spotting this bug, I forgot that the monster blocks had their own Block Behaviour.

Also fixed a very minor bug in stage 2 part 1, where the monster block was using the sand texture instead of the stone texture.